### PR TITLE
github: publish on Crates.io

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -1,0 +1,34 @@
+name: Crates
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish_docs:
+    name: Publish documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build documentation
+        run: cargo doc --no-deps
+      - name: Publish documentation
+        run: |
+          cd target/doc
+          git init
+          git add .
+          git -c user.name='tigroo31' -c user.email='tigroo@lilo.org' commit -m init
+          git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
+        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish
+        run: cargo publish --token ${{ secrets.CRATES_IO }}
+

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,25 +22,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build source
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-
-  publish_docs:
-    name: Publish documentation
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v2
-      - name: Build documentation
-        run: cargo doc --no-deps
-      - name: Publish documentation
-        run: |
-          cd target/doc
-          git init
-          git add .
-          git -c user.name='tigroo31' -c user.email='tigroo@lilo.org' commit -m init
-          git push -f -q https://git:${{ secrets.github_token }}@github.com/${{ github.repository }} HEAD:gh-pages
-        if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
-
+      - name: Build source
+        run: cargo build --verbose
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libflow"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "log",
  "ordered-float",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libflow"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Pascale Borscia <pascale.borscia@orange.com>",
     "Frédéric Gardes <frederic.gardes@orange.com>"]
 license = "MIT/Apache-2.0"


### PR DESCRIPTION
Add a dedicated workflow for Crates.
Publish library and documentation only on merge into the master, 
not for a pull request.

**How to test:**

It will be alittle bit curious : let's accept the pull request, and check on the merge into the master, the publish crates.io and doc.rs triggers were well processed (let's go into the Actions part to see them).
