### PR TITLE
Allow flow id copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "libflow"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libflow"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Pascale Borscia <pascale.borscia@orange.com>",
     "Frédéric Gardes <frederic.gardes@orange.com>"]
 license = "MIT/Apache-2.0"

--- a/src/flow_id.rs
+++ b/src/flow_id.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// another flow with the same
 /// transport protocol, and the src IP and port from one
 /// equal to the dest IP and port of the other.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct FlowId {
     /// Source IP address
     pub src: IpAddr,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -48,6 +48,12 @@ impl Generator {
         self.flow_map.get_mut(k)
     }
 
+    /// Returns `true` if the map contains a value for the specified key.
+    #[inline]
+    pub fn contains_key(&self, k: &FlowId) -> bool {
+        self.flow_map.contains_key(k)
+    }
+
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
     #[inline]
     pub fn entry(&mut self, key: FlowId) -> Entry<'_, FlowId, FlowInformation> {


### PR DESCRIPTION
Allow to copy the flow id (to store it as key into Collections).
Expose the research by key.